### PR TITLE
Update math_object.cpp

### DIFF
--- a/src/kjs/math_object.cpp
+++ b/src/kjs/math_object.cpp
@@ -142,7 +142,7 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
 
     switch (id) {
     case MathObjectImp::Abs:
-        result = (arg < 0.0 || (arg == 0.0 && signbit(arg)) ? (-arg) : arg;
+        result = (arg < 0.0 || (arg == 0.0 && signbit(arg))) ? (-arg) : arg;
         break;
     case MathObjectImp::ACos:
         result = ::acos(arg);

--- a/src/kjs/math_object.cpp
+++ b/src/kjs/math_object.cpp
@@ -69,7 +69,7 @@ const ClassInfo MathObjectImp::info = { "Math", 0, &mathTable, 0 };
   atanh         MathObjectImp::ATanH    DontEnum|Function 1
   cbrt          MathObjectImp::Cbrt     DontEnum|Function 1
   cosh          MathObjectImp::CosH     DontEnum|Function 1
-  exmp1         MathObjectImp::Exmp1    DontEnum|Function 1
+  expm1         MathObjectImp::Expm1    DontEnum|Function 1
   log1p         MathObjectImp::Log1p    DontEnum|Function 1
   log10         MathObjectImp::Log10    DontEnum|Function 1
   log2          MathObjectImp::Log2     DontEnum|Function 1
@@ -77,7 +77,7 @@ const ClassInfo MathObjectImp::info = { "Math", 0, &mathTable, 0 };
   sinh          MathObjectImp::SinH     DontEnum|Function 1
   tanh          MathObjectImp::TanH     DontEnum|Function 1
   trunc         MathObjectImp::Trunc    DontEnum|Function 1
-  hypot         MathObjectImp::Hypot    DontEnum|Function 0
+  hypot         MathObjectImp::Hypot    DontEnum|Function 2
   imul          MathObjectImp::Imul     DontEnum|Function 2
   fround        MathObjectImp::FRound   DontEnum|Function 1
   clz32         MathObjectImp::Clz32    DontEnum|Function 1
@@ -142,7 +142,7 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
 
     switch (id) {
     case MathObjectImp::Abs:
-        result = (arg < 0 || arg == -0) ? (-arg) : arg;
+        result = (arg < 0.0 || (arg == 0.0 && signbit(arg)) ? (-arg) : arg;
         break;
     case MathObjectImp::ACos:
         result = ::acos(arg);
@@ -223,11 +223,8 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
         result = (double)rand() / RAND_MAX;
         break;
     case MathObjectImp::Round:
-        if (signbit(arg) && arg >= -0.5) {
-            result = -0.0;
-        } else {
-            result = ::floor(arg + 0.5);
-        }
+        double ceil = ::ceil(arg);
+        result = ceil - (ceil - 0.5 > arg ? 1 : 0);
         break;
     case MathObjectImp::Sin:
         result = ::sin(arg);
@@ -255,7 +252,7 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
     case MathObjectImp::CosH:
         result = ::cosh(arg);
         break;
-    case MathObjectImp::Exmp1:
+    case MathObjectImp::Expm1:
         result = ::expm1(arg);
         break;
     case MathObjectImp::Log1p:
@@ -305,6 +302,7 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
         }
 
         double sum = 0.0;
+        double max = 0.0;
         bool foundNaN = false;
         for (int i = 0; i < args.size(); ++i)
         {
@@ -318,20 +316,28 @@ JSValue *MathFuncImp::callAsFunction(ExecState *exec, JSObject * /*thisObj*/, co
                 foundNaN = true;
                 continue;
             }
-
-            sum += ::pow(num, 2);
+            double abs = num > 0.0 ? num : 0.0 - num;
+            if (abs != 0.0)
+            {
+                if (abs > max)
+                {
+                    sum *= (max / abs) * (max / abs);
+                    max = abs;
+                }
+                sum += (abs / max) * (abs / max);
+            }
         }
 
         if (foundNaN)
             return jsNumber(KJS::NaN);
 
-        result = ::sqrt(sum);
+        result = max * ::sqrt(sum);
         break;
     }
     case MathObjectImp::Imul:
     {
         if (args.size() < 2)
-            return jsUndefined();
+            return jsNumber(0.0);
         int32_t a = args[0]->toInt32(exec);
         if (exec->hadException())
             return jsNumber(a);

--- a/src/kjs/math_object.cpp
+++ b/src/kjs/math_object.cpp
@@ -109,7 +109,7 @@ JSValue *MathObjectImp::getValueProperty(ExecState *, int token) const
     case Log2E:
         return jsNumber(1.0 / log(2.0));
     case Log10E:
-        return jsNumber(1.0 / log(10.0));
+        return jsNumber(0.4342944819032518);
     case Pi:
         return jsNumber(piDouble);
     case Sqrt1_2:

--- a/src/kjs/math_object.cpp
+++ b/src/kjs/math_object.cpp
@@ -65,7 +65,7 @@ const ClassInfo MathObjectImp::info = { "Math", 0, &mathTable, 0 };
   sqrt          MathObjectImp::Sqrt     DontEnum|Function 1
   tan           MathObjectImp::Tan      DontEnum|Function 1
   acosh         MathObjectImp::ACosH    DontEnum|Function 1
-  acosh         MathObjectImp::ASinH    DontEnum|Function 1
+  asinh         MathObjectImp::ASinH    DontEnum|Function 1
   atanh         MathObjectImp::ATanH    DontEnum|Function 1
   cbrt          MathObjectImp::Cbrt     DontEnum|Function 1
   cosh          MathObjectImp::CosH     DontEnum|Function 1

--- a/src/kjs/math_object.h
+++ b/src/kjs/math_object.h
@@ -43,7 +43,7 @@ public:
            Abs, ACos, ASin, ATan, ATan2, Ceil, Cos, Pow,
            Exp, Floor, Log, Max, Min, Random, Round, Sin, Sqrt, Tan,
            //ES6 (draft 08.11.2013)
-           ACosH, ASinH, ATanH, Cbrt, CosH, Exmp1,
+           ACosH, ASinH, ATanH, Cbrt, CosH, Expm1,
            Log1p, Log10, Log2, Sign, SinH, TanH, Trunc,
            Hypot, Imul, FRound, Clz32
          };


### PR DESCRIPTION
fixes for:
`Math.exmp1` - the name should be `expm1`;
`Math.hypot.length` should give 2;
`Math.abs(+0)` should give positive zero;
`Math.round(0.49999999999999994)` should give `0`, not `1`, `Math.round(-9007199254740991)` should give `-9007199254740991`, not `-9007199254740990`, `Math.round(+9007199254740991)` should give `+9007199254740991`, not `+9007199254740992`;
`Math.hypot` -  `Implementations should take care to avoid the loss of precision from overflows and underflows that are prone to occur in naive implementations when this function is called with two or more arguments.` (https://tc39.github.io/ecma262/#sec-math.hypot);
`Math.imul()` should give `0`;
`Math.asinh` was not exposed;
`Math.LOG10E` has an inaccurate value
